### PR TITLE
Add missing config values

### DIFF
--- a/src/components/ConfigTabs/DreamvisitorConfigTab.tsx
+++ b/src/components/ConfigTabs/DreamvisitorConfigTab.tsx
@@ -88,11 +88,6 @@ const BasicSettings = memo(({ config, setConfig, space }: {
   const handleNumberChange = useDebouncedCallback((field: keyof ConfigState, value: number | null) => {
     setConfig(prev => ({ ...prev, [field]: value === null ? 0 : value }));
   }, 300);
-
-  const handleTextChange = useDebouncedCallback((field: keyof ConfigState, value: string) => {
-    setConfig(prev => ({ ...prev, [field]: value }));
-  }, 300);
-
   // Make sure config is safe to use
   if (!config) return null;
 
@@ -139,14 +134,14 @@ const BasicSettings = memo(({ config, setConfig, space }: {
       />
       <Space h={space} />
       <NumberInput
-        label='Player Limit Override'
+        label='Whitelist Port'
         description='The port to use to accept web whitelist requests.'
         value={config?.whitelistPort ?? 0}
         onChange={(val) => handleNumberChange('whitelistPort', val === "" ? 0 : Number(val))}
       />
       <Space h={space} />
       <NumberInput
-        label='Whitelist Port'
+        label='Player Limit Override'
         description='Player limit override. This will override the player limit, both over and under. This can be set in Minecraft with /playerlimit <int>'
         value={config?.playerLimit ?? 0}
         onChange={(val) => handleNumberChange('playerLimit', val === "" ? 0 : Number(val))}

--- a/src/components/ConfigTabs/DreamvisitorConfigTab.tsx
+++ b/src/components/ConfigTabs/DreamvisitorConfigTab.tsx
@@ -19,6 +19,8 @@ const toCamelCase = (str: string): string => {
 const EconomyFieldset = lazy(() => import('./EconomyFieldset'));
 const InfractionsFieldset = lazy(() => import('./InfractionsFieldset'));
 const MailFieldset = lazy(() => import('./MailFieldset'));
+const FlightFieldset = lazy(() => import('./FlightFieldset'));
+const InactivityTaxFieldset = lazy(() => import('./InactivityTaxFieldset'));
 
 // Using memo to prevent unnecessary re-renders
 const MemoizedLocationInput = memo(LocationInput);
@@ -44,7 +46,9 @@ interface ConfigState {
   softWhitelist: boolean;
   disablePvP: boolean;
   playerLimit: number;
+  whitelistPort: number;
   resourcePackRepo: string | null;
+  noWitherNotice: string | null;
   hubLocation: Location | null;
   whitelistChannel: number | null;
   gameChatChannel: number | null;
@@ -63,6 +67,16 @@ interface ConfigState {
   mailDeliveryLocationSelectionDistanceWeightMultiplier: number;
   mailDistanceToRewardMultiplier: number;
   consoleSize: number;
+  flightEnergyCapacity: number,
+  flightRegenerationPoint: number,
+  flightEnergyRegeneration: number,
+  flightEnergyDepletionXZMultiplier: number,
+  flightEnergyDepletionYMultiplier: number,
+  daysUntilInactiveTax: number,
+  inactiveTaxPercent: number,
+  inactiveDayFrequency: number,
+  inactiveTaxStop: number,
+  lastInactiveTax: number
 }
 
 // Basic settings component to reduce main component size
@@ -126,6 +140,13 @@ const BasicSettings = memo(({ config, setConfig, space }: {
       <Space h={space} />
       <NumberInput
         label='Player Limit Override'
+        description='The port to use to accept web whitelist requests.'
+        value={config?.whitelistPort ?? 0}
+        onChange={(val) => handleNumberChange('whitelistPort', val === "" ? 0 : Number(val))}
+      />
+      <Space h={space} />
+      <NumberInput
+        label='Whitelist Port'
         description='Player limit override. This will override the player limit, both over and under. This can be set in Minecraft with /playerlimit <int>'
         value={config?.playerLimit ?? 0}
         onChange={(val) => handleNumberChange('playerLimit', val === "" ? 0 : Number(val))}
@@ -139,6 +160,17 @@ const BasicSettings = memo(({ config, setConfig, space }: {
         onChange={(e) => {
           const { value } = e.currentTarget;
           setConfig(prev => ({ ...prev, resourcePackRepo: value }))
+        }}
+      />
+      <Space h={space} />
+      <TextInput
+        label='No Wither Notice'
+        placeholder='Withers cannot be spawned here. You can only spawn Withers in the Wither chamber.'
+        description='The message sent if a Wither is built in a region where the wither flag is denied.'
+        value={config?.noWitherNotice || ''}
+        onChange={(e) => {
+          const { value } = e.currentTarget;
+          setConfig(prev => ({ ...prev, noWitherNotice: value }))
         }}
       />
     </>
@@ -212,7 +244,9 @@ export function DreamvisitorConfigTab({ space }: DreamvisitorConfigTabProps) {
     softWhitelist: false,
     disablePvP: false,
     playerLimit: -1,
+    whitelistPort: 10826,
     resourcePackRepo: "WOFTNW/Dragonspeak",
+    noWitherNotice: "Withers cannot be spawned here. You can only spawn Withers in the Wither chamber.",
     hubLocation: null,
     whitelistChannel: null,
     gameChatChannel: null,
@@ -231,6 +265,16 @@ export function DreamvisitorConfigTab({ space }: DreamvisitorConfigTabProps) {
     mailDeliveryLocationSelectionDistanceWeightMultiplier: 1.00,
     mailDistanceToRewardMultiplier: 0.05,
     consoleSize: 512,
+    flightEnergyCapacity: 400,
+    flightRegenerationPoint: 200.00,
+    flightEnergyRegeneration: 1.00,
+    flightEnergyDepletionXZMultiplier: 4.00,
+    flightEnergyDepletionYMultiplier: 10.00,
+    daysUntilInactiveTax: 60,
+    inactiveTaxPercent: 0.1,
+    inactiveDayFrequency: 7,
+    inactiveTaxStop: 50000,
+    lastInactiveTax: 0
   }));
 
   const [originalConfig, setOriginalConfig] = useState<ConfigState>({ ...config });
@@ -649,6 +693,10 @@ export function DreamvisitorConfigTab({ space }: DreamvisitorConfigTabProps) {
         {renderLazyComponent(EconomyFieldset, { config, setConfig, space })}
         <Space h={space} />
         {renderLazyComponent(MailFieldset, { config, setConfig, space })}
+        <Space h={space} />
+        {renderLazyComponent(FlightFieldset, { config, setConfig, space })}
+        <Space h={space} />
+        {renderLazyComponent(InactivityTaxFieldset, { config, setConfig, space })}
         <Space h={space} />
         <Divider />
         <Space h={space} />

--- a/src/components/ConfigTabs/FlightFieldset.tsx
+++ b/src/components/ConfigTabs/FlightFieldset.tsx
@@ -1,0 +1,76 @@
+import React, { memo } from 'react';
+import { Fieldset, TextInput, NumberInput, Space } from '@mantine/core';
+import { useDebouncedCallback } from '@mantine/hooks';
+
+interface FlightFieldsetProps {
+  config: any;
+  setConfig: React.Dispatch<React.SetStateAction<any>>;
+  space: string;
+}
+
+function FlightFieldset({ config, setConfig, space }: FlightFieldsetProps) {
+  // Debounce input changes to reduce re-renders
+  const handleNumberChange = useDebouncedCallback((field: string, value: string | number | null) => {
+    setConfig((prev: any) => ({ ...prev, [field]: Number(value) }));
+  }, 300);
+
+  const handleTextChange = useDebouncedCallback((field: string, value: string) => {
+    setConfig((prev: any) => ({ ...prev, [field]: value }));
+  }, 300);
+
+  return (
+    <Fieldset legend="Flight">
+      <NumberInput
+        label='Flight Energy Capacity'
+        placeholder='400'
+        description='The maximum amount of flight energy.'
+        value={config.flightEnergyCapacity}
+        onChange={(val) => handleNumberChange('flightEnergyCapacity', val)}
+        decimalScale={0}
+        step={1}
+      />
+      <Space h={space} />
+      <NumberInput
+        label='Flight Regeneration Point'
+        placeholder='200.00'
+        description='The maximum amount of flight energy.'
+        value={config.flightRegenerationPoint}
+        onChange={(val) => handleNumberChange('flightRegenerationPoint', val)}
+        decimalScale={2}
+        step={1}
+      />
+      <Space h={space} />
+      <NumberInput
+        label='Flight Energy Regeneration'
+        placeholder='1.00'
+        description='The rate at which energy is regenerated per tick.'
+        value={config.flightEnergyRegeneration}
+        onChange={(val) => handleNumberChange('flightEnergyRegeneration', val)}
+        decimalScale={2}
+        step={0.1}
+      />
+      <Space h={space} />
+      <NumberInput
+        label='Flight Energy Depletion X/Z Multiplier'
+        placeholder='4.00'
+        description='The rate at which movement on the X and Z axes depletes energy while flying.'
+        value={config.flightEnergyDepletionXZMultiplier}
+        onChange={(val) => handleNumberChange('flightEnergyDepletionXZMultiplier', val)}
+        decimalScale={2}
+        step={0.1}
+      />
+      <Space h={space} />
+      <NumberInput
+        label='Flight Energy Depletion Y Multiplier'
+        placeholder='10.00'
+        description='The rate at which movement on the Y axes depletes energy while flying.'
+        value={config.flightEnergyDepletionYMultiplier}
+        onChange={(val) => handleNumberChange('flightEnergyDepletionYMultiplier', val)}
+        decimalScale={2}
+        step={0.1}
+      />
+    </Fieldset>
+  );
+}
+
+export default memo(FlightFieldset);

--- a/src/components/ConfigTabs/InactivityTaxFieldset.tsx
+++ b/src/components/ConfigTabs/InactivityTaxFieldset.tsx
@@ -1,0 +1,76 @@
+import React, { memo } from 'react';
+import { Fieldset, TextInput, NumberInput, Space } from '@mantine/core';
+import { useDebouncedCallback } from '@mantine/hooks';
+
+interface InactivityTaxFieldsetProps {
+  config: any;
+  setConfig: React.Dispatch<React.SetStateAction<any>>;
+  space: string;
+}
+
+function InactivityTaxFieldset({ config, setConfig, space }: InactivityTaxFieldsetProps) {
+  // Debounce input changes to reduce re-renders
+  const handleNumberChange = useDebouncedCallback((field: string, value: string | number | null) => {
+    setConfig((prev: any) => ({ ...prev, [field]: Number(value) }));
+  }, 300);
+
+  const handleTextChange = useDebouncedCallback((field: string, value: string) => {
+    setConfig((prev: any) => ({ ...prev, [field]: value }));
+  }, 300);
+
+  return (
+    <Fieldset legend="InactivityTax">
+      <NumberInput
+        label='Days Until Inactive Tax'
+        placeholder='60'
+        description='The days a player can be offline until the inactivity tax applies.'
+        value={config.daysUntilInactiveTax}
+        onChange={(val) => handleNumberChange('daysUntilInactiveTax', val)}
+        decimalScale={0}
+        step={1}
+      />
+      <Space h={space} />
+      <NumberInput
+        label='Inactive Tax Percent'
+        placeholder='0.1'
+        description='The percent to tax inactive players, between 0.0 and 1.0.'
+        value={config.inactiveTaxPercent}
+        onChange={(val) => handleNumberChange('inactiveTaxPercent', val)}
+        decimalScale={2}
+        step={0.01}
+      />
+      <Space h={space} />
+      <NumberInput
+        label='Inactive Day Frequency'
+        placeholder='7'
+        description='The time in days between inactivity taxes. 0 to disable.'
+        value={config.inactiveDayFrequency}
+        onChange={(val) => handleNumberChange('inactiveDayFrequency', val)}
+        decimalScale={0}
+        step={1}
+      />
+      <Space h={space} />
+      <NumberInput
+        label='Inactive Tax Stop'
+        placeholder='50000'
+        description='The lowest a balance can be depleted to by inactivity taxes.'
+        value={config.inactiveTaxStop}
+        onChange={(val) => handleNumberChange('inactiveTaxStop', val)}
+        decimalScale={0}
+        step={100}
+      />
+      <Space h={space} />
+      <NumberInput
+        label='Last Inactive Tax'
+        placeholder='0'
+        description='The last time the inactive tax occurred. This should not be manually tampered with.'
+        value={config.lastInactiveTax}
+        onChange={(val) => handleNumberChange('lastInactiveTax', val)}
+        decimalScale={0}
+        step={0}
+      />
+    </Fieldset>
+  );
+}
+
+export default memo(InactivityTaxFieldset);


### PR DESCRIPTION
Add new config values from Dreamvisitor main, notably:

- whitelistPort
- noWitherNotice
- Flight
  - flightEnergyCapacity
  - flightRegenerationPoint
  - flightEnergyRegeneration
  - flightEnergyDepletionXZMultiplier
  - flightEnergyDepletionYMultiplier
- Inactive Tax
  - daysUntilInactiveTax
  - inactiveTaxPercent
  - inactiveDayFrequency
  - inactiveTaxStop
  - lastInactiveTax