### PR TITLE
Insert and read user IDs in URL for addressed user pages

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -42,7 +42,7 @@ const router = createBrowserRouter([
     ),
   },
   {
-    path: '/users',
+    path: '/users/*',
     element: (
       <ProtectedRoute>
         <UsersPage />

--- a/src/components/DiscordUserTable/DiscordUserTable.tsx
+++ b/src/components/DiscordUserTable/DiscordUserTable.tsx
@@ -5,7 +5,7 @@ import { pb } from '@/lib/pocketbase';
 
 
 interface DiscordUserTableProps {
-  setOpened: (value: boolean) => void;
+  setOpened: (value: boolean, userId?: string) => void;
   users: User[];
   onUserSelect: (userId: string) => void;
 }
@@ -18,7 +18,7 @@ export function DiscordUserTable({ setOpened, users, onUserSelect }: DiscordUser
       className={classes.row}
       onClick={() => {
         onUserSelect(user.id);
-        setOpened(false);
+        setOpened(false, user.id);
       }}
     >
       <Table.Td>

--- a/src/components/UserTable/UserTable.tsx
+++ b/src/components/UserTable/UserTable.tsx
@@ -8,7 +8,7 @@ import { useEffect, useState, useRef, useCallback } from 'react';
 
 interface UserTableProps {
   opened: boolean;
-  setOpened: (value: boolean) => void;
+  setOpened: (value: boolean, userId?: string) => void;
   setSelectedUserId: (id: string) => void;
 }
 

--- a/src/pages/Users.page.tsx
+++ b/src/pages/Users.page.tsx
@@ -1,21 +1,45 @@
 import { NavbarSimple } from '@/components/NavbarSimple/NavbarSimple';
 import { UserProfile } from '@/components/UserProfile/UserProfile';
 import { UserTable } from '@/components/UserTable/UserTable';
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useEffect } from 'react';
 
 export function UsersPage() {
-  const [opened, setOpened] = useState(true); // Start with the user list open
+  const [listOpen, setOpened] = useState(true); // Start with the user list open
   const [selectedUserId, setSelectedUserId] = useState<string | null>(null); // No user selected initially
 
   // Use callback to prevent unnecessary re-renders
   const handleUserSelect = useCallback((userId: string) => {
+    console.log("handle user select");
     setSelectedUserId(userId);
+    console.log(userId);
+    
     setOpened(false); // Close the table and show the profile
   }, []);
 
   // Use callback for toggling between views
-  const toggleView = useCallback((isTableVisible: boolean) => {
+  const toggleView = useCallback((isTableVisible: boolean, userId?: string) => {
+    console.log("toggle view");
     setOpened(isTableVisible);
+    console.log(userId);
+    
+    if (isTableVisible) {
+      window.history.replaceState(null, "", "/users");
+    } else {
+      window.history.replaceState(null, "", "/users/" + userId);
+    }
+  }, []);
+  
+  // Automatically open user if defined in URL
+  useEffect(() => {
+    console.log("use effect");
+    
+    console.log(location.pathname);
+    let id: string = location.pathname.split("/users/")[1];
+    console.log(id);
+    
+    if (id) {
+      handleUserSelect(id);
+    }
   }, []);
 
   return (
@@ -25,14 +49,15 @@ export function UsersPage() {
         <div style={{ margin: 'var(--mantine-spacing-xl)', width: '100%' }}>
           <div style={{ display: 'grid' }}>
             <UserProfile
-              opened={!opened}
-              setOpened={toggleView}
+              opened={!listOpen}
               userId={selectedUserId}
+              setOpened={toggleView}
+
             />
             <UserTable
-              opened={opened}
-              setOpened={toggleView}
+              opened={listOpen}
               setSelectedUserId={handleUserSelect}
+              setOpened={toggleView}
             />
           </div>
         </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -223,15 +223,15 @@
   resolved "https://registry.npmjs.org/@dual-bundle/import-meta-resolve/-/import-meta-resolve-4.1.0.tgz"
   integrity sha512-+nxncfwHM5SgAtrVzgpzJOI1ol0PkumhVo469KCf9lUi21IGcY90G98VuHm9VRrUypmAzawAHO9bs6hqeADaVg==
 
-"@esbuild/win32-x64@0.21.5":
+"@esbuild/linux-x64@0.21.5":
   version "0.21.5"
-  resolved "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz"
-  integrity sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==
+  resolved "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz"
+  integrity sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==
 
-"@esbuild/win32-x64@0.23.1":
+"@esbuild/linux-x64@0.23.1":
   version "0.23.1"
-  resolved "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.23.1.tgz"
-  integrity sha512-BHpFFeslkWrXWyUPnbKm+xYYVYruCinGcftSBaa8zoF9hZO4BcSCFUvHVTtzpIY6YzUnYtuEhZ+C9iEXjxnasg==
+  resolved "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.23.1.tgz"
+  integrity sha512-EV6+ovTsEXCPAp58g2dD68LxoP/wK5pRvgy0J/HxPGB009omFPv3Yet0HiaqvrIrgPTBuC6wCH1LTOY91EO5hQ==
 
 "@eslint-community/eslint-utils@^4.2.0", "@eslint-community/eslint-utils@^4.4.0":
   version "4.4.0"
@@ -456,10 +456,15 @@
     estree-walker "^2.0.2"
     picomatch "^2.3.1"
 
-"@rollup/rollup-win32-x64-msvc@4.24.0":
+"@rollup/rollup-linux-x64-gnu@4.24.0":
   version "4.24.0"
-  resolved "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.24.0.tgz"
-  integrity sha512-fbMkAF7fufku0N2dE5TBXcNlg0pt0cJue4xBRE2Qc5Vqikxr4VCgKj/ht6SMdFcOacVA9rqF70APJ8RN/4vMJw==
+  resolved "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.24.0.tgz"
+  integrity sha512-ZXFk7M72R0YYFN5q13niV0B7G8/5dcQ9JDp8keJSfr3GoZeXEoMHP/HlvqROA3OMbMdfr19IjCeNAnPUG93b6A==
+
+"@rollup/rollup-linux-x64-musl@4.24.0":
+  version "4.24.0"
+  resolved "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.24.0.tgz"
+  integrity sha512-w1i+L7kAXZNdYl+vFvzSZy8Y1arS7vMgIy8wusXJzRrPyof5LAb02KGr1PD2EkRcl73kHulIID0M501lN+vobQ==
 
 "@storybook/addon-controls@^8.3.6":
   version "8.3.6"


### PR DESCRIPTION
When clicking on a user in the user select, the user's database ID is added to the URL, and removed when returning to the user list. On initial load with the user ID after /users/, the user with the given ID will be opened immediately. This allows user pages to be referenced by URL for saving or sharing.

![image](https://github.com/user-attachments/assets/cf6c1a9d-4844-435d-bcd7-0ceb9edfe3fb)

![image](https://github.com/user-attachments/assets/07fbb0b3-8254-4f25-b139-38a426708fc3)
